### PR TITLE
Adjust health drain rate, berry's price, and steps required for XP

### DIFF
--- a/TingoApp/Assets/Feed.cs
+++ b/TingoApp/Assets/Feed.cs
@@ -8,9 +8,9 @@ using UnityEngine.SceneManagement;
 public class Feed : MonoBehaviour {
 	
 	float berryValue = .1f;				//How much berries raise health by
-	float healthDrainRate = .027f;		//How much health is lost per hour (this takes 36 houres to starve)
+	float healthDrainRate = .037f;		//How much health is lost per hour (this takes 36 houres to starve)
 
-	int steps = 1375;				//This will be replaced with the actual steps that were gathered that day
+	int steps = 1000;				//This will be replaced with the actual steps that were gathered that day
 
 	private PedometerPlugin pedometerPlugin;
 

--- a/TingoApp/Assets/Menu.cs
+++ b/TingoApp/Assets/Menu.cs
@@ -11,8 +11,8 @@ public class Menu : MonoBehaviour {
 	GameObject sliderObj;
 	PedometerPlugin pedometerPlugin;
 
-	int STEPS_PER_BERRY = 500;
-	int STEPS_PER_XP = 1000;
+	int STEPS_PER_BERRY = 1000;
+	int STEPS_PER_XP = 1700;
 
 	public void changeScene(string loadScene){
 		SceneManager.LoadScene(loadScene);


### PR DESCRIPTION
#44 I doubled berry'price and set the step to require for XP to 1700. Also, I made the health drain rate faster because the tingo has never died when I playing it. 