### PR TITLE
Reduce Times Getting Stuck Flipping

### DIFF
--- a/TingoApp/Assets/Scripts/SpeechAnim/testSpeach.cs
+++ b/TingoApp/Assets/Scripts/SpeechAnim/testSpeach.cs
@@ -25,8 +25,8 @@ public class testSpeach : MonoBehaviour {
 	private AudioSource sourceHmm;
 
 	//used for animations
-	float jumpTime = .8f;
-	float jumpHeight = 5.0f;
+	float jumpTime = .7f;
+	float jumpHeight = 4.0f;
 	float realHeight = .5947088f;
 
 	//used for sentiment analysis
@@ -174,7 +174,7 @@ public class testSpeach : MonoBehaviour {
 			timer += Time.deltaTime;
 			yield return null;
 		}
-
+		transform.localPosition = new Vector3(transform.localPosition.x, 0.0f, transform.localPosition.z);
 		transform.localPosition = new Vector3(transform.localPosition.x, .5947088f, transform.localPosition.z);
 	}
 


### PR DESCRIPTION
Changed some initial values for the jump height and time, along with introducing a line to attempt to regulate the y-value of the Tingo after a jump to allow less times getting stuck. In my testing, this has reduced the amount of times he has gotten stuck at weird elevations, although it doesn't seem to aid too much with the initial vertical stick and the interactions between Tingo and the table.

#49 