### PR TITLE
Set values of playerprefs when app is first installed

### DIFF
--- a/TingoApp/Assets/Feed.cs
+++ b/TingoApp/Assets/Feed.cs
@@ -55,10 +55,20 @@ public class Feed : MonoBehaviour {
 			var health = healthSlider.value;
 			PlayerPrefs.SetFloat ("health", health);
 			if (health <= 0) {
-				PlayerPrefs.SetInt("baseSubtract", pedometerPlugin.GetTotalStep());
-//				pedometerPlugin.DeleteData ();
-//				pedometerPlugin.StopPedometerService ();
-				changeScene ("death");
+				//Check if app has been installed for the first time
+				if (PlayerPrefs.GetInt ("hasRan") == 0) {
+					PlayerPrefs.SetInt ("berries",5);
+					PlayerPrefs.SetFloat ("xp", 0);
+					PlayerPrefs.SetFloat ("health", 1);
+					PlayerPrefs.SetInt ("level", 0);
+					PlayerPrefs.SetInt ("steps", 0);
+					PlayerPrefs.SetInt ("hasRan",1);
+					healthSlider.value = 1;
+				} else {
+					PlayerPrefs.SetInt ("baseSubtract", pedometerPlugin.GetTotalStep ());
+					changeScene ("death");
+				}
+
 			}
 		}
 	

--- a/TingoApp/Assets/Menu.cs
+++ b/TingoApp/Assets/Menu.cs
@@ -32,7 +32,7 @@ public class Menu : MonoBehaviour {
 	}
 
 	public void Update(){
-
+		
 		pedometerPlugin = PedometerPlugin.GetInstance ();
 
 		levelObj = GameObject.Find ("level");
@@ -51,7 +51,6 @@ public class Menu : MonoBehaviour {
 
 			//set xp slider fullness
 			Slider xpSlider = sliderObj.GetComponent<Slider>();
-			Debug.Log (xpSlider != null);
 			xpSlider.value = toNextLevel;
 		}
 	}

--- a/TingoApp/ProjectSettings/ProjectSettings.asset
+++ b/TingoApp/ProjectSettings/ProjectSettings.asset
@@ -243,7 +243,7 @@ PlayerSettings:
   AndroidTargetDevice: 0
   AndroidSplashScreenScale: 0
   androidSplashScreen: {fileID: 0}
-  AndroidKeystoreName: C:/Users/JonHiggins/Documents/GitHub/Tingo/TingoApp/user.keystore
+  AndroidKeystoreName: C:/Users/bense/OneDrive/Documents/GitHub/Tingo/TingoApp/user.keystore
   AndroidKeyaliasName: tingo
   AndroidTVCompatibility: 1
   AndroidIsGame: 1

--- a/TingoApp/ProjectSettings/ProjectVersion.txt
+++ b/TingoApp/ProjectSettings/ProjectVersion.txt
@@ -1,1 +1,1 @@
-m_EditorVersion: 2017.4.0f1
+m_EditorVersion: 2017.4.1f1


### PR DESCRIPTION
Fixed #80, the app was making up vales for playerprefs, and picked 0 for health because it had not been set yet.